### PR TITLE
Updated Dockerfile.skr to add execution permissions to test scripts

### DIFF
--- a/docker/skr/Dockerfile.skr
+++ b/docker/skr/Dockerfile.skr
@@ -5,4 +5,4 @@ RUN apk update && apk add curl
 COPY ./bin/skr ./bin/get-snp-report /bin/
 COPY skr.sh tests/*_client.sh /
 RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr
-RUN chmod +x /*.sh; date > /made-date
+RUN chmod +x /*.sh /tests/skr/*.sh; date > /made-date


### PR DESCRIPTION
Added executable permissions for the test skr scripts in the Dockerfile used for bulding the skr container. This is to ensure that the scripts can be executed.

Signed-off-by: Stavros Volos <svolos@gmail.com>