### PR TITLE
adding verbose report endpoint, updating error messages, updating docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
 /azmount
 /remotefs
+
+# temp files
+**/*.o
+
+# dev environment
+.vscode
+
+# compiled programs
+verbose-report
+get-snp-report
+get-fake-snp-report
+skr
+!skr/
+**/bin

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ The code in this repository should be located at ``$GOPATH/src/microsoft/confide
 For more information on how the tools work and the sidecar's base64-encoded string attributes, check [the tecnical documentation](./TECH-INFO.md).
 
 ## Secure key release (SKR) sidecar
-The ``docker/skr/build.sh`` script builds all necessary Go tools for secure key release as standalone binaries and creates a Docker image that contains them so that it 
-can be used as a sidecar container. The skr sidecar container is executed by calling the script ``skr.sh`` with a base64-encoded string as an attribute or as an environment variable. 
+The ``docker/skr/build.sh`` script builds all necessary Go tools for secure key release as standalone binaries and creates a Docker image that contains them so that it
+can be used as a sidecar container. The skr sidecar container is executed by calling the script ``skr.sh`` with a base64-encoded string as an attribute or as an environment variable.
 
 The skr sidecar can be queried by application containers hosted in the same pod (or container group) for retrieving attestation reports and for releasing secrets from managed HSM key vaults.
 
 The ``examples/skr`` shows an example of how the skr sidecar can be deployed and tested within a confidential container group on ACI.
 
-### Third-party code 
+### Third-party code
 We modified the [AES unwrap key without padding method](https://github.com/NickBall/go-aes-key-wrap/blob/master/keywrap.go) to implement the aes key unwrap with padding method.
 
 ## Encrypted filesystem sidecar

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 <!-- BEGIN MICROSOFT SECURITY.MD V0.0.7 BLOCK -->
 
-## Security
+# Security
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
@@ -14,17 +14,17 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 

--- a/cmd/skr/README.md
+++ b/cmd/skr/README.md
@@ -34,8 +34,8 @@ The `status` GET method returns the status of the server. The response carries a
 The `attest/raw` POST method expects a JSON of the following format:
 
 ```json
-{	    
-    "runtime_data": "<Base64-encoded blob; the hash digest of the blob will be presented as report data in the raw attestation report>"    
+{
+    "runtime_data": "<Base64-encoded blob; the hash digest of the blob will be presented as report data in the raw attestation report>"
 }
 ```
 
@@ -55,12 +55,63 @@ Upon error, the `attest/raw` POST method response carries a `BadRequest` or `Sta
 }
 ```
 
+The `attest/json` POST method expects a JSON of the following format:
+
+```json
+{
+    "runtime_data": "<Base64-encoded blob that will be presented as ReportData in hardware attestation report>"
+}
+```
+
+Upon success, the `attest/json` POST method response carries a `StatusOK` header and a payload of the following format:
+
+```json
+{
+    "report": {
+        "version": int,
+        "guest_svn": int,
+        "policy": int,
+        "family_id": string,
+        "image_id": string,
+        "vmpl": int,
+        "signature_algo": int,
+        "platform_version": int,
+        "platform_info": int,
+        "author_key_en": int,
+        "reserved1": int,
+        "report_data": string,
+        "measurement": string,
+        "host_data": string,
+        "id_key_digest": string,
+        "author_key_digest": string,
+        "report_id": string,
+        "report_id_ma": string,
+        "reported_tcb": int,
+        "reserved2":string,
+        "chip_id": string,
+        "committed_svn": int,
+        "committed_version": int,
+        "launch_svn": int,
+        "reserved3": string,
+        "signature": string
+    }
+}
+```
+
+Upon error, the `attest/json` POST method response carries a `BadRequest` or `StatusForbidden` header and a payload of the following format:
+
+```json
+{
+    "error": "<error message>"
+}
+```
+
 The `attest/maa` POST method expects a JSON of the following format:
 
 ```json
-{	
+{
     "maa_endpoint": "<maa endpoint>",
-    "runtime_data": "<Base64-encoded blob whose hash digest will be presented as runtime data in maa token>"    
+    "runtime_data": "<Base64-encoded blob whose hash digest will be presented as runtime data in maa token>"
 }
 ```
 
@@ -83,7 +134,7 @@ Upon error, the `attest/maa` POST method response carries a `BadRequest` or `Sta
 The `key/release` POST method expects a JSON of the following format:
 
 ```json
-{	
+{
     "maa_endpoint": "<maa endpoint>",
     "mhsm_endpoint": "<mhsm endpoint>",
     "kid": "<key identifier>",

--- a/docker/skr/Dockerfile.skr
+++ b/docker/skr/Dockerfile.skr
@@ -6,3 +6,6 @@ COPY ./bin/skr ./bin/get-snp-report /bin/
 COPY skr.sh tests/*_client.sh /
 RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr
 RUN chmod +x /*.sh /tests/skr/*.sh; date > /made-date
+
+WORKDIR /
+CMD [ "./skr.sh" ]

--- a/docker/skr/skr.sh
+++ b/docker/skr/skr.sh
@@ -17,7 +17,7 @@ if [[ -z "${SkrSideCarArgs}" ]]; then
   else
     echo "0" > result
   fi
-else 
+else
   if /bin/skr -logfile /log.txt -base64 $SkrSideCarArgs; then
       echo "1" > result
   else

--- a/docker/skr/tests/json_report_client.sh
+++ b/docker/skr/tests/json_report_client.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Important note: This script is meant to run from inside the container
+
+if [[ -z "${AttestClientRuntimeData}" ]]; then
+  AttestClientRuntimeData=$1
+fi
+
+echo AttestClientRuntimeData = $AttestClientRuntimeData
+
+while true; do
+  curl -X POST -H 'Content-Type: application/json' -d "{\"runtime_data\": \"$AttestClientRuntimeData\"}" http://localhost:8080/attest/json > /jsonreport.out;
+  sleep 5;
+done

--- a/examples/skr/README.md
+++ b/examples/skr/README.md
@@ -3,6 +3,7 @@
 In our confidential container group example, we will deploy the skr sidecar along with a set of test containers that exercise and test the REST API.
 - **skr sidecar.** The sidecar’s entry point is /skr.sh which uses the SkrSideCarArgs environment variable to pass the certificate cache endpoint information.
 - **attest/raw test.** The sidecar’s entry point is /tests/attest_client.sh which uses the AttestClientRuntimeData environment variable to pass a blob whose sha-256 digest will be encoded in the raw attestation report as report_data.
+- **attest/json test.** The sidecar’s entry point is /tests/json_report_client.sh which uses the AttestClientRuntimeData environment variable to pass a blob whose sha-256 digest will be encoded in the attestation report as report_data.
 - **attest/maa test.** The sidecar’s entry point is /tests/attest_client.sh which uses two environment variables: (i) AttestClientMAAEndpoint passes the Microsoft Azure Attestation endpoint which will author the attestation token, (ii) AttestClientRuntimeData passes a blob whose sha-256 digest will be encoded in the attestation token as runtime claim.
 - **key/release test.** The sidecar’s entry point is /tests/skr_client.sh which uses the three environment variables: (i) SkrClientKID passes the key identifier of the key to be released from the MHSM, (ii) SkrClientMHSMEndpoint passes the MHSM endpoint from which the key will be released, and (iii) SkrClientMAAEndpoint passes the Microsoft Azure Attestation endpoint shall author the attestation token required for releasing the secret. The MAA endpoint shall be the same as the one specified in the SKR policy during the key import to the MHSM.
 
@@ -18,9 +19,9 @@ Deploying a confidential container group requires generating a security policy t
 
 `az confcom acipolicygen -i policy-in.json -s policy-out.json -orp`
 
-The policy-input file includes three entries: (i) skr sidecar container which whitelists the /skr.sh as entry point command and the environment variable SkrSideCarArgs used by the script, (ii) attest_client container which whitelists the /tests/attest_client.sh as entry point command and a set of environment variables used by the script and whose names begin with AttestClient, and  (iii) skr_client container which whitelists the /tests/skr_client.sh as entry point command and a set of environment variables used by the script and whose names begin with SkrClient. 
+The policy-input file includes four entries: (i) skr sidecar container which whitelists the /skr.sh as entry point command and the environment variable SkrSideCarArgs used by the script, (ii) attest_client container which whitelists the /tests/attest_client.sh as entry point command and a set of environment variables used by the script and whose names begin with AttestClient, (iii) skr_client container which whitelists the /tests/skr_client.sh as entry point command and a set of environment variables used by the script and whose names begin with SkrClient, and (iv) json_report_client container which whitelists the /tests/json_report_client.sh as entry point command and an environment variable with the name: AttestClientRuntimeData.
 Please note that:
-- The skr sidecar must be allowed to execute as elevated because it needs access to the PSP which is mounted as a device at /dev/sev. 
+- The skr sidecar must be allowed to execute as elevated because it needs access to the PSP which is mounted as a device at /dev/sev.
 - The policy includes one entry for both attestation tests, as both tests use the same entry point and a superset of environment variables whitelisted by the AttestClient regular expression.
 
 ### Import key

--- a/examples/skr/aci-arm-template.json
+++ b/examples/skr/aci-arm-template.json
@@ -49,7 +49,7 @@
                 }
               ]
             }
-          },          
+          },
           {
             "name": "test-skr-client-container",
             "properties": {
@@ -111,6 +111,27 @@
                   "name": "AttestClientMAAEndpoint",
                   "value": "<maa-endpoint>"
                 },
+                {
+                  "name": "AttestClientRuntimeData",
+                  "value": "eyJrZXlzIjpbeyJlIjoiQVFBQiIsImtleV9vcHMiOlsiZW5jcnlwdCJdLCJraWQiOiJOdmhmdXEyY0NJT0FCOFhSNFhpOVByME5QXzlDZU16V1FHdFdfSEFMel93Iiwia3R5IjoiUlNBIiwibiI6InY5NjVTUm15cDh6Ykc1ZU5GdURDbW1pU2VhSHB1akcyYkNfa2VMU3V6dkRNTE8xV3lyVUp2ZWFhNWJ6TW9PMHBBNDZwWGttYnFIaXNvelZ6cGlORExDbzZkM3o0VHJHTWVGUGYyQVBJTXUtUlNyek41NnF2SFZ5SXI1Y2FXZkhXay1GTVJEd0FlZnlOWVJIa2RZWWtnbUZLNDRoaFVkdGxDQUtFdjVVUXBGWmp2aDRpSTlqVkJkR1lNeUJhS1FMaGpJNVdJaC1RRzZaYTVzU3VPQ0ZNbm11eXV2TjVEZmxwTEZ6NTk1U3MtRW9CSVktTmlsNmxDdHZjR2dSLUlialVZSEFPczVhamFtVHpnZU84a3gzVkNFOUhjeUtteVVac2l5aUY2SURScDJCcHkzTkhUakl6N3Rta3BUSHg3dEhuUnRsZkUyRlV2MEI2aV9RWWxfWkE1USJ9XX0="
+                }
+              ],
+              "image": "<registry-name>/aci-skr:1.1",
+              "resources": {
+                "requests": {
+                  "cpu": 1,
+                  "memoryInGB": 1
+                }
+              }
+            }
+          },
+          {
+            "name": "test-json_report-client-container",
+            "properties": {
+              "command": [
+                "/tests/json_report_client.sh"
+              ],
+              "environmentVariables": [
                 {
                   "name": "AttestClientRuntimeData",
                   "value": "eyJrZXlzIjpbeyJlIjoiQVFBQiIsImtleV9vcHMiOlsiZW5jcnlwdCJdLCJraWQiOiJOdmhmdXEyY0NJT0FCOFhSNFhpOVByME5QXzlDZU16V1FHdFdfSEFMel93Iiwia3R5IjoiUlNBIiwibiI6InY5NjVTUm15cDh6Ykc1ZU5GdURDbW1pU2VhSHB1akcyYkNfa2VMU3V6dkRNTE8xV3lyVUp2ZWFhNWJ6TW9PMHBBNDZwWGttYnFIaXNvelZ6cGlORExDbzZkM3o0VHJHTWVGUGYyQVBJTXUtUlNyek41NnF2SFZ5SXI1Y2FXZkhXay1GTVJEd0FlZnlOWVJIa2RZWWtnbUZLNDRoaFVkdGxDQUtFdjVVUXBGWmp2aDRpSTlqVkJkR1lNeUJhS1FMaGpJNVdJaC1RRzZaYTVzU3VPQ0ZNbm11eXV2TjVEZmxwTEZ6NTk1U3MtRW9CSVktTmlsNmxDdHZjR2dSLUlialVZSEFPczVhamFtVHpnZU84a3gzVkNFOUhjeUtteVVac2l5aUY2SURScDJCcHkzTkhUakl6N3Rta3BUSHg3dEhuUnRsZkUyRlV2MEI2aV9RWWxfWkE1USJ9XX0="

--- a/examples/skr/policy-in.json
+++ b/examples/skr/policy-in.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0",
     "containers": [
-        {            
+        {
             "containerImage": "<registry-name>/aci-skr:1.1",
             "environmentVariables": [
                 {
@@ -10,10 +10,10 @@
                     "strategy": "re2"
                 }
             ],
-            "command": [ "/skr.sh" ],               
+            "command": [ "/skr.sh" ],
             "allow_elevated": true
-        },        
-        {            
+        },
+        {
             "containerImage": "<registry-name>/aci-skr:1.1",
             "environmentVariables": [
                 {
@@ -21,11 +21,11 @@
                     "value": ".+",
                     "strategy": "re2"
                 }
-            ],            
+            ],
             "command": [ "/tests/skr_client.sh" ],
             "allow_elevated": false
-        },        
-        {            
+        },
+        {
             "containerImage": "<registry-name>/aci-skr:1.1",
             "environmentVariables": [
                 {
@@ -33,8 +33,20 @@
                     "value": ".+",
                     "strategy": "re2"
                 }
-            ],            
+            ],
             "command": [ "/tests/attest_client.sh" ],
+            "allow_elevated": false
+        },
+        {
+            "containerImage": "<registry-name>/aci-skr:1.1",
+            "environmentVariables": [
+                {
+                    "name": "((?i)AttestClient).+",
+                    "value": ".+",
+                    "strategy": "re2"
+                }
+            ],
+            "command": [ "/tests/json_report_client.sh" ],
             "allow_elevated": false
         }
     ]

--- a/pkg/attest/README.md
+++ b/pkg/attest/README.md
@@ -1,6 +1,8 @@
+# Attest
+
 This package implements the Attest operation to fetch an attestation token from MAA. It interacts with the following Azure services:
+
 - Certificate Cache (certcache): for retrieving the certificate chain which will be used by MAA to validate the signature of the attestation report;
 - Microsoft Azure Attestation (maa): for issuing an attestation token given an attestation report signed by a key that is rooted to the cert chain, and additional evidence including the blobs that have been hashed to the report's `HOST_DATA` and `REPORT_DATA` fields during virtual machine bringup and retrieval of the attestation report, respectively;
 
 The attestation report is fetched from the platform security processor by executing the <parent>/tools/get-snp-report tool which is compiled and copied into the container's root filesystem under /bin.
-

--- a/pkg/common/README.md
+++ b/pkg/common/README.md
@@ -1,3 +1,5 @@
+# Common
+
 This package implements a range of methods that are used across sub-packages.
 
-`token` enables retrieving an authentication token if run within an Azure VM. The Azure VM needs to be assigned a managed identity that has proper permissions to the Azure resource that requires authentication.
+The `token` tool enables retrieving an authentication token if run within an Azure VM. The Azure VM needs to be assigned a managed identity that has proper permissions to the Azure resource that requires authentication.

--- a/pkg/skr/README.md
+++ b/pkg/skr/README.md
@@ -1,2 +1,3 @@
-This package implements the Secure Key Release operation to release a secret previously imported to Azure Key Vault managed HSM. It interacts with the local attesation library to fetch an MAA token and then uses the MAA token when interacting with the Azure Key Vault managed HSM (mhsm) service for releasing a secret previously imported to the key vault with a user-defined release policy. The MHSM API expects an authentication token that has proper permissions to the MHSM.
+# Secure Key Release
 
+This package implements the Secure Key Release operation to release a secret previously imported to Azure Key Vault managed HSM. It interacts with the local attesation library to fetch an MAA token and then uses the MAA token when interacting with the Azure Key Vault managed HSM (mhsm) service for releasing a secret previously imported to the key vault with a user-defined release policy. The MHSM API expects an authentication token that has proper permissions to the MHSM.


### PR DESCRIPTION
adding actionable instructions to error messages, fixing markdown linting in docs.

This requirement came from the Confidential ACI public preview weekly meetings.

Customer containers should be able to access attestation info from somewhere inside the confidential container group. Because the SKR container is already accessing this hardware info, putting a verbose attestation report endpoint into the SKR container's web server is semi-trivial and will not occupy extra resources (as it would if it was split into an independent container).