### PR TITLE
Root build from github.com/Microsoft/confidential-sidecar-containers.

### DIFF
--- a/TECH-INFO.md
+++ b/TECH-INFO.md
@@ -137,7 +137,7 @@ Other command line options are:
 # skr
 We also provide a stand-alone tool for attestation and secure key release. This tool instantiates a web server which exposes a REST API so that other containers can retrieve a hardware attestation report via the POST method `attest/raw` or an MAA token via the POST method `attest/maa`, and release a key via the POST method `key/release`. The server is configured with a certificate cache endpoint during startup, and can be reached at http://localhost:8080. 
 
-The tool can be executed using the script https://github.com/microsoft/confidential-sidecars/blob/skr.sh and optionally the certificate cache endpoint information as an attribute to it or as an environment variable `SkrSidecarArgs`. If the script is executed without any certificate cache endpoint information, only  the `attest/raw` POST method is available.
+The tool can be executed using the script https://github.com/Microsoft/confidential-sidecard-containers/blob/skr.sh and optionally the certificate cache endpoint information as an attribute to it or as an environment variable `SkrSidecarArgs`. If the script is executed without any certificate cache endpoint information, only  the `attest/raw` POST method is available.
 
 The information for the cerificate cache endpoint is passed as a base64-encoded string and has the following schema
 

--- a/TECH-INFO.md
+++ b/TECH-INFO.md
@@ -137,7 +137,7 @@ Other command line options are:
 # skr
 We also provide a stand-alone tool for attestation and secure key release. This tool instantiates a web server which exposes a REST API so that other containers can retrieve a hardware attestation report via the POST method `attest/raw` or an MAA token via the POST method `attest/maa`, and release a key via the POST method `key/release`. The server is configured with a certificate cache endpoint during startup, and can be reached at http://localhost:8080. 
 
-The tool can be executed using the script https://github.com/Microsoft/confidential-sidecard-containers/blob/skr.sh and optionally the certificate cache endpoint information as an attribute to it or as an environment variable `SkrSidecarArgs`. If the script is executed without any certificate cache endpoint information, only  the `attest/raw` POST method is available.
+The tool can be executed using the script https://github.com/Microsoft/confidential-sidecar-containers/blob/skr.sh and optionally the certificate cache endpoint information as an attribute to it or as an environment variable `SkrSidecarArgs`. If the script is executed without any certificate cache endpoint information, only  the `attest/raw` POST method is available.
 
 The information for the cerificate cache endpoint is passed as a base64-encoded string and has the following schema
 

--- a/buildall.sh
+++ b/buildall.sh
@@ -10,11 +10,11 @@ set -e
 mkdir -p bin
 pushd bin
 echo building skr
-CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/skr
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/skr
 echo building azmount
-CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/azmount
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/azmount
 echo building remotefs
-CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/remotefs
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/remotefs
 popd
 
 echo building get-snp-report

--- a/buildall.sh
+++ b/buildall.sh
@@ -7,14 +7,14 @@ set -e
 
 # This script builds all binaries
 
-mkdir bin
+mkdir -p bin
 pushd bin
 echo building skr
-CGO_ENABLED=0 GOOS=linux go build github.com/microsoft/confidential-sidecars/cmd/skr
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/skr
 echo building azmount
-CGO_ENABLED=0 GOOS=linux go build github.com/microsoft/confidential-sidecars/cmd/azmount
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/azmount
 echo building remotefs
-CGO_ENABLED=0 GOOS=linux go build github.com/microsoft/confidential-sidecars/cmd/remotefs
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/remotefs
 popd
 
 echo building get-snp-report

--- a/cmd/azmount/filemanager/azure.go
+++ b/cmd/azmount/filemanager/azure.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/cmd/azmount/filemanager/azure.go
+++ b/cmd/azmount/filemanager/azure.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/cmd/azmount/fuse.go
+++ b/cmd/azmount/fuse.go
@@ -10,7 +10,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/microsoft/confidential-sidecars/cmd/azmount/filemanager"
+	"github.com/Microsoft/confidential-sidecard-containers/cmd/azmount/filemanager"
 	"github.com/pkg/errors"
 )
 

--- a/cmd/azmount/fuse.go
+++ b/cmd/azmount/fuse.go
@@ -10,7 +10,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/Microsoft/confidential-sidecard-containers/cmd/azmount/filemanager"
+	"github.com/Microsoft/confidential-sidecar-containers/cmd/azmount/filemanager"
 	"github.com/pkg/errors"
 )
 

--- a/cmd/azmount/main.go
+++ b/cmd/azmount/main.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/Microsoft/confidential-sidecard-containers/cmd/azmount/filemanager"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/cmd/azmount/filemanager"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/azmount/main.go
+++ b/cmd/azmount/main.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/microsoft/confidential-sidecars/cmd/azmount/filemanager"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/cmd/azmount/filemanager"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/remotefs/azurefs.go
+++ b/cmd/remotefs/azurefs.go
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//go:build linux
 // +build linux
 
 package main
@@ -17,9 +18,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/skr"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"

--- a/cmd/remotefs/azurefs.go
+++ b/cmd/remotefs/azurefs.go
@@ -17,9 +17,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/microsoft/confidential-sidecars/pkg/attest"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
-	"github.com/microsoft/confidential-sidecars/pkg/skr"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"

--- a/cmd/remotefs/main.go
+++ b/cmd/remotefs/main.go
@@ -11,9 +11,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/skr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/remotefs/main.go
+++ b/cmd/remotefs/main.go
@@ -11,9 +11,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/microsoft/confidential-sidecars/pkg/attest"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
-	"github.com/microsoft/confidential-sidecars/pkg/skr"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/skr/README.md
+++ b/cmd/skr/README.md
@@ -12,7 +12,7 @@ This tool instantiates a web server ( http://localhost:8080 ) which exposes a RE
 }
 ```
 
-The tool can be executed using the script https://github.com/microsoft/confidential-sidecars/blob/master/skr.sh and the base64-encoded string as an optional cert cache endpoint attribute to it.
+The tool can be executed using the script https://github.com/Microsoft/confidential-sidecard-containers/blob/master/skr.sh and the base64-encoded string as an optional cert cache endpoint attribute to it.
 
 If the cert cache endpoint is not provided, only the `attest/raw` POST method is available.
 

--- a/cmd/skr/README.md
+++ b/cmd/skr/README.md
@@ -12,7 +12,7 @@ This tool instantiates a web server ( http://localhost:8080 ) which exposes a RE
 }
 ```
 
-The tool can be executed using the script https://github.com/Microsoft/confidential-sidecard-containers/blob/master/skr.sh and the base64-encoded string as an optional cert cache endpoint attribute to it.
+The tool can be executed using the script https://github.com/Microsoft/confidential-sidecar-containers/blob/master/skr.sh and the base64-encoded string as an optional cert cache endpoint attribute to it.
 
 If the cert cache endpoint is not provided, only the `attest/raw` POST method is available.
 

--- a/cmd/skr/main.go
+++ b/cmd/skr/main.go
@@ -13,9 +13,9 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"github.com/microsoft/confidential-sidecars/pkg/attest"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
-	"github.com/microsoft/confidential-sidecars/pkg/skr"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/cmd/skr/main.go
+++ b/cmd/skr/main.go
@@ -12,10 +12,10 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/skr"
 	"github.com/gin-gonic/gin"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/docker/encfs/build.sh
+++ b/docker/encfs/build.sh
@@ -10,9 +10,9 @@ set -e
 mkdir bin
 pushd bin
 echo building azmount
-CGO_ENABLED=0 GOOS=linux go build github.com/microsoft/confidential-sidecars/cmd/azmount
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/azmount
 echo building remotefs
-CGO_ENABLED=0 GOOS=linux go build github.com/microsoft/confidential-sidecars/cmd/remotefs
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/remotefs
 popd 
 
 echo building get-snp-report

--- a/docker/encfs/build.sh
+++ b/docker/encfs/build.sh
@@ -10,9 +10,9 @@ set -e
 mkdir bin
 pushd bin
 echo building azmount
-CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/azmount
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/azmount
 echo building remotefs
-CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/remotefs
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/remotefs
 popd 
 
 echo building get-snp-report

--- a/docker/skr/build.sh
+++ b/docker/skr/build.sh
@@ -9,7 +9,7 @@ set -e
 
 mkdir bin
 pushd bin
-CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/skr
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/skr
 popd
 
 pushd ../../tools/get-snp-report

--- a/docker/skr/build.sh
+++ b/docker/skr/build.sh
@@ -9,7 +9,7 @@ set -e
 
 mkdir bin
 pushd bin
-CGO_ENABLED=0 GOOS=linux go build github.com/microsoft/confidential-sidecars/cmd/skr
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecard-containers/cmd/skr
 popd
 
 pushd ../../tools/get-snp-report

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Microsoft/confidential-sidecard-containers
+module github.com/Microsoft/confidential-sidecar-containers
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/microsoft/confidential-sidecars
+module github.com/Microsoft/confidential-sidecard-containers
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ github.com/Azure/go-autorest/autorest/adal v0.9.13 h1:Mp5hbtOePIzM8pJVRa3YLrWWmZ
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
-github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
@@ -88,7 +87,6 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/stephens2424/writerset v1.0.2/go.mod h1:aS2JhsMn6eA7e82oNmW4rfsgAOp9COBTTl8mzkwADnc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -106,7 +104,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 h1:3wPMTskHO3+O6jqTEXyFcsnuxMQOqYSaHsDxcbUXpqA=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -116,7 +113,6 @@ golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
@@ -138,7 +134,6 @@ golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 h1:7ZDGnxgHAMw7thfC5bEos0RDA
 golang.org/x/sys v0.0.0-20210915083310-ed5796bab164/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/attest/attest_test.go
+++ b/pkg/attest/attest_test.go
@@ -13,7 +13,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/attest/attest_test.go
+++ b/pkg/attest/attest_test.go
@@ -13,7 +13,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/attest/certcache.go
+++ b/pkg/attest/certcache.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/attest/certcache.go
+++ b/pkg/attest/certcache.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/attest/maa.go
+++ b/pkg/attest/maa.go
@@ -10,7 +10,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/attest/maa.go
+++ b/pkg/attest/maa.go
@@ -10,7 +10,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/skr/mhsm.go
+++ b/pkg/skr/mhsm.go
@@ -18,9 +18,9 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/skr/mhsm.go
+++ b/pkg/skr/mhsm.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -8,8 +8,8 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 
-	"github.com/microsoft/confidential-sidecars/pkg/attest"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -8,8 +8,8 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/attest"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/skr/skr_test.go
+++ b/pkg/skr/skr_test.go
@@ -13,10 +13,10 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
-
-	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+	
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/skr/skr_test.go
+++ b/pkg/skr/skr_test.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/skr/skr_test.go
+++ b/pkg/skr/skr_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws"
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/skr/skr_test.go
+++ b/pkg/skr/skr_test.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"testing"
 	
-	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/jwx/jws"
 	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jws"	
 	"github.com/pkg/errors"
 )
 

--- a/tools/get-token/main.go
+++ b/tools/get-token/main.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
 )
 
 func main() {

--- a/tools/get-token/main.go
+++ b/tools/get-token/main.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/microsoft/confidential-sidecars/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
 )
 
 func main() {

--- a/tools/importkey/main.go
+++ b/tools/importkey/main.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/microsoft/confidential-sidecars/pkg/common"
-	"github.com/microsoft/confidential-sidecars/pkg/skr"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
 )
 
 type importKeyConfig struct {

--- a/tools/importkey/main.go
+++ b/tools/importkey/main.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/common"
-	"github.com/Microsoft/confidential-sidecard-containers/pkg/skr"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/skr"
 )
 
 type importKeyConfig struct {


### PR DESCRIPTION
Use checkout and build path rooted at github.com/Microsoft/confidential-sidecar-containers rather than github.com/microsoft/confidential-sidecars to match hcsshim. Note case change from m to M in Microsoft too.