### PR TITLE
Updating skr.sh to pass in PORT and create log.txt under home dir

### DIFF
--- a/docker/skr/skr.sh
+++ b/docker/skr/skr.sh
@@ -11,14 +11,20 @@ fi
 
 echo SkrSideCarArgs = $SkrSideCarArgs
 
+if [[ -z "${Port}" ]]; then
+  Port=$2
+else 
+  Port = "8080"
+fi
+
 if [[ -z "${SkrSideCarArgs}" ]]; then
-  if /bin/skr -logfile /log.txt; then
+  if /bin/skr -logfile ./log.txt -port $Port; then
     echo "1" > result
   else
     echo "0" > result
   fi
 else 
-  if /bin/skr -logfile /log.txt -base64 $SkrSideCarArgs; then
+  if /bin/skr -logfile ./log.txt -base64 $SkrSideCarArgs -port $Port; then
       echo "1" > result
   else
       echo "0" > result

--- a/docker/skr/skr.sh
+++ b/docker/skr/skr.sh
@@ -5,28 +5,32 @@
 
 # Important note: This script is meant to run from inside the container
 
-if [[ -z "${SkrSideCarArgs}" ]]; then
+CmdlineArgs="-logfile ./log.txt"
+
+if [ -z "${SkrSideCarArgs}" ]; then
   SkrSideCarArgs=$1
 fi
 
 echo SkrSideCarArgs = $SkrSideCarArgs
 
-if [[ -z "${Port}" ]]; then
-  Port=$2
-else 
-  Port = "8080"
+if [ -n "${SkrSideCarArgs}" ]; then
+  CmdlineArgs="${CmdlineArgs} -base64 ${SkrSideCarArgs}"
 fi
 
-if [[ -z "${SkrSideCarArgs}" ]]; then
-  if /bin/skr -logfile ./log.txt -port $Port; then
-    echo "1" > result
-  else
-    echo "0" > result
-  fi
-else 
-  if /bin/skr -logfile ./log.txt -base64 $SkrSideCarArgs -port $Port; then
-      echo "1" > result
-  else
-      echo "0" > result
-  fi
+if [ -z "${Port}" ]; then
+  Port=$2
+fi
+
+echo Port = $Port
+
+if [ -n "${Port}" ]; then
+  CmdlineArgs="${CmdlineArgs} -port ${Port}"
+fi
+
+echo CmdlineArgs = $CmdlineArgs
+
+if /bin/skr $CmdlineArgs; then
+  echo "1" > result
+else
+  echo "0" > result
 fi


### PR DESCRIPTION
- The port parameter that was passed into skr.sh was not being passed onto the skr launch. Passing that thru.
- Log file location of "/log.txt" creates it under root (/) which fails if the container is launched as non-root eg when launching skr under UID/GID of say 1337. Changing to "./log.txt" so that the file gets created under the user's home directory.

Signed-off-by: gaurav137 <39692417+gaurav137@users.noreply.github.com>