### PR TITLE
Avoid failing to build due to bin directory being present already.

### DIFF
--- a/docker/encfs/build.sh
+++ b/docker/encfs/build.sh
@@ -7,7 +7,7 @@ set -e
 
 # This script builds the encrypted filesystem container
 
-mkdir bin
+mkdir -p bin
 pushd bin
 echo building azmount
 CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/azmount
@@ -25,4 +25,4 @@ cp ../../tools/get-snp-report/bin/get-fake-snp-report ./bin
 docker build --tag encfs -f Dockerfile.encfs .
 
 # clean up
-rm -r bin
+rm -rf bin

--- a/docker/skr/build.sh
+++ b/docker/skr/build.sh
@@ -7,7 +7,7 @@ set -e
 
 # This script builds the binaries and sets up the docker image
 
-mkdir bin
+mkdir -p bin
 pushd bin
 CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/skr
 popd
@@ -22,4 +22,4 @@ cp ../../tools/get-snp-report/bin/get-fake-snp-report ./bin
 docker build --tag skr -f Dockerfile.skr .
 
 # cleanup
-rm -r bin
+rm -rf bin


### PR DESCRIPTION
Various mkdir -p bin and rm -rf bin such that if the build fails halfway through, for example if docker desktop is not running, then a subsequent attempt may succeed. 