### PR TITLE
Check error of released key before checking its type + logging

### DIFF
--- a/cmd/skr/main.go
+++ b/cmd/skr/main.go
@@ -187,13 +187,12 @@ func postKeyRelease(c *gin.Context) {
 	}
 
 	jwKey, err := skr.SecureKeyRelease(Identity, skrKeyBlob, EncodedUvmInformation)
-
-	logrus.Debugf("Key released of type %s", jwKey.KeyType())
-
 	if err != nil {
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
 		return
 	}
+
+	logrus.Debugf("Key released of type %s", jwKey.KeyType())
 
 	jwkJSONBytes, err := json.Marshal(jwKey)
 	if err != nil {

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -116,6 +116,7 @@ func SecureKeyRelease(identity common.Identity, SKRKeyBlob KeyBlob, uvmInformati
 
 	keyBytes, kty, err := SKRKeyBlob.AKV.ReleaseKey(maaToken, SKRKeyBlob.KID, privateWrappingKey)
 	if err != nil {
+		logrus.Debugf("releasing the key %s failed. err: %s", SKRKeyBlob.KID, err.Error())
 		return nil, errors.Wrapf(err, "releasing the key %s failed", SKRKeyBlob.KID)
 	}
 


### PR DESCRIPTION
There was logging (subject to no error) before we check the error from the release operation. Fixed the order. 