### PR TITLE
Support file rather than env based scheme to acquire policy, uvm info and certs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+**.o
 /azmount
 /remotefs
+/tools/get-snp-report/bin
+/bin

--- a/docker/skr/Dockerfile.debug
+++ b/docker/skr/Dockerfile.debug
@@ -14,7 +14,7 @@ RUN mkdir /run/sshd
 # which can be used to trick an attestation agent or relying party
 
 COPY ./bin/skr ./bin/get-snp-report ./bin/verbose-report /bin/
-COPY skr.sh test-local.sh attest.sh skr-debug.sh tests/*_client.sh /
+COPY skr.sh skr-debug.sh tests/*_client.sh /
 RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr
 RUN chmod +x /*.sh /tests/skr/*.sh; date > /made-date
 

--- a/docker/skr/Dockerfile.debug
+++ b/docker/skr/Dockerfile.debug
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+RUN apt update
+RUN apt install --fix-missing -y net-tools wget curl bc jq bash vim ssh
+
+# clearly this is extremely insecure but is only for debugging
+# do not copy this.
+RUN useradd --uid 1000 --gid 0 --non-unique -ms /bin/bash auserwithalongname
+RUN echo "auserwithalongname:shortpassword" | chpasswd
+RUN mkdir /run/sshd
+
+# set the start command which will be used by default by ACI
+# note that this script exposes attestation on an external port
+# NEVER DO THIS IN PRODUCTION as it exposes the attestations
+# which can be used to trick an attestation agent or relying party
+
+COPY ./bin/skr ./bin/get-snp-report ./bin/verbose-report /bin/
+COPY skr.sh test-local.sh attest.sh skr-debug.sh tests/*_client.sh /
+RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr
+RUN chmod +x /*.sh /tests/skr/*.sh; date > /made-date
+
+# set the start command
+CMD [ "sleep", "1000000" ]

--- a/docker/skr/build-debug.sh
+++ b/docker/skr/build-debug.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+# This script builds the binaries and sets up the docker image
+
+mkdir -p bin
+pushd bin
+CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/skr
+popd
+
+pushd ../../tools/get-snp-report
+make 
+popd
+
+cp ../../tools/get-snp-report/bin/get-snp-report ./bin
+cp ../../tools/get-snp-report/bin/get-fake-snp-report ./bin
+cp ../../tools/get-snp-report/bin/verbose-report ./bin
+
+docker build --tag skr -f Dockerfile.debug .
+
+# cleanup
+rm -rf bin

--- a/docker/skr/skr-debug.sh
+++ b/docker/skr/skr-debug.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Important note: This script is meant to run from inside the container
+
+echo starting sshd
+/usr/sbin/sshd &
+
+CmdlineArgs="-logfile ./log.txt"
+
+if [ -z "${SkrSideCarArgs}" ]; then
+  SkrSideCarArgs=$1
+fi
+
+echo SkrSideCarArgs = $SkrSideCarArgs
+
+if [ -n "${SkrSideCarArgs}" ]; then
+  CmdlineArgs="${CmdlineArgs} -base64 ${SkrSideCarArgs}"
+fi
+
+if [ -z "${Port}" ]; then
+  Port=$2
+fi
+
+echo Port = $Port
+
+if [ -n "${Port}" ]; then
+  CmdlineArgs="${CmdlineArgs} -port ${Port}"
+fi
+
+echo CmdlineArgs = $CmdlineArgs
+
+if /bin/skr $CmdlineArgs; then
+  echo "1" > result
+else
+  echo "0" > result
+fi

--- a/docker/skr/tests/attest_client.sh
+++ b/docker/skr/tests/attest_client.sh
@@ -5,20 +5,20 @@
 
 # Important note: This script is meant to run from inside the container
 
-if [[ -z "${AttestClientRuntimeData}" ]]; then
+if [ -z "${AttestClientRuntimeData}" ]; then
   AttestClientRuntimeData=$1  
 fi
 
 echo AttestClientRuntimeData = $AttestClientRuntimeData
 
-if [[ -z "${AttestClientMAAEndpoint}" ]]; then
+if [ -z "${AttestClientMAAEndpoint}" ]; then
   AttestClientMAAEndpoint=$2
 fi
 
 echo AttestClientMAAEndpoint = $AttestClientMAAEndpoint
 
 while true; do
-  if [[ -z "${AttestClientMAAEndpoint}" ]]; then
+  if [ -z "${AttestClientMAAEndpoint}" ]; then
     curl -X POST -H 'Content-Type: application/json' -d "{\"runtime_data\": \"$AttestClientRuntimeData\"}" http://localhost:8080/attest/raw > /raw.out;  
   else
     curl -X POST -H 'Content-Type: application/json' -d "{\"maa_endpoint\": \"$AttestClientMAAEndpoint\", \"runtime_data\": \"$AttestClientRuntimeData\"}" http://localhost:8080/attest/maa > /maatoken.out; 

--- a/docker/skr/tests/skr_client.sh
+++ b/docker/skr/tests/skr_client.sh
@@ -5,19 +5,19 @@
 
 # Important note: This script is meant to run from inside the container
 
-if [[ -z "${SkrClientMAAEndpoint}" ]]; then
+if [ -z "${SkrClientMAAEndpoint}" ]; then
   SkrClientMAAEndpoint=$1
 fi
 
 echo SkrClientMAAEndpoint = $SkrClientMAAEndpoint
 
-if [[ -z "${SkrClientAKVEndpoint}" ]]; then
+if [ -z "${SkrClientAKVEndpoint}" ]; then
   SkrClientAKVEndpoint=$2
 fi
 
 echo SkrClientAKVEndpoint = $SkrClientAKVEndpoint
 
-if [[ -z "${SkrClientKID}" ]]; then
+if [ -z "${SkrClientKID}" ]; then
   SkrClientKID=$3
 fi
 

--- a/pkg/common/info.go
+++ b/pkg/common/info.go
@@ -156,12 +156,12 @@ func GetUvmInfomationFromFiles() (UvmInformation, error) {
 
 	encodedUvmInformation.EncodedSecurityPolicy, err = readSecurityContextFile(securityContextDir, PolicyFilename)
 	if err != nil {
-		return encodedUvmInformation, errors.Wrapf(err, "reading host amd cert failed")
+		return encodedUvmInformation, errors.Wrapf(err, "reading security policy failed")
 	}
 
 	encodedUvmInformation.EncodedUvmReferenceInfo, err = readSecurityContextFile(securityContextDir, ReferenceInfoFilename)
 	if err != nil {
-		return encodedUvmInformation, errors.Wrapf(err, "reading host amd cert failed")
+		return encodedUvmInformation, errors.Wrapf(err, "reading uvm reference info failed")
 	}
 
 	if GenerateTestData {

--- a/pkg/common/info.go
+++ b/pkg/common/info.go
@@ -9,6 +9,7 @@ import (
 
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -65,7 +66,26 @@ func THIMtoPEM(encodedHostCertsFromTHIM string) (string, error) {
 	return certsString, nil
 }
 
+// Late in Public Preview, we made a change to pass the UVM information
+// via files instead of environment variables.
+// This code detects which method is being used and calls the appropriate
+// function to get the UVM information.
+
+// The environment variable scheme will go away by "General Availability"
+// but we handle both to decouple this code and the hcsshim/gcs code.
+
+// Matching PR https://github.com/microsoft/hcsshim/pull/1708
+
 func GetUvmInfomation() (UvmInformation, error) {
+	securityContextDir := os.Getenv("UVM_SECURITY_CONTEXT_DIR")
+	if securityContextDir != "" {
+		return GetUvmInfomationFromFiles()
+	} else {
+		return GetUvmInfomationFromEnv()
+	}
+}
+
+func GetUvmInfomationFromEnv() (UvmInformation, error) {
 	var encodedUvmInformation UvmInformation
 	encodedHostCertsFromTHIM := os.Getenv("UVM_HOST_AMD_CERTIFICATE")
 
@@ -82,6 +102,67 @@ func GetUvmInfomation() (UvmInformation, error) {
 	}
 	encodedUvmInformation.EncodedSecurityPolicy = os.Getenv("UVM_SECURITY_POLICY")
 	encodedUvmInformation.EncodedUvmReferenceInfo = os.Getenv("UVM_REFERENCE_INFO")
+
+	if GenerateTestData {
+		ioutil.WriteFile("uvm_security_policy.base64", []byte(encodedUvmInformation.EncodedSecurityPolicy), 0644)
+		ioutil.WriteFile("uvm_reference_info.base64", []byte(encodedUvmInformation.EncodedUvmReferenceInfo), 0644)
+	}
+
+	return encodedUvmInformation, nil
+}
+
+// From hcsshim pkg/securitypolicy/securitypolicy.go
+
+const (
+	SecurityContextDirTemplate = "security-context-*"
+	PolicyFilename             = "security-policy-base64"
+	HostAMDCertFilename        = "host-amd-cert-base64"
+	ReferenceInfoFilename      = "reference-info-base64"
+)
+
+func readSecurityContextFile(dir string, filename string) (string, error) {
+	targetFilename := filepath.Join(dir, filename)
+	blob, err := os.ReadFile(targetFilename)
+	if err != nil {
+		return "", err
+	}
+	return string(blob), nil
+}
+
+func GetUvmInfomationFromFiles() (UvmInformation, error) {
+	var encodedUvmInformation UvmInformation
+
+	securityContextDir := os.Getenv("UVM_SECURITY_CONTEXT_DIR")
+	if securityContextDir == "" {
+		return encodedUvmInformation, errors.New("UVM_SECURITY_CONTEXT_DIR not set")
+	}
+
+	encodedHostCertsFromTHIM, err := readSecurityContextFile(securityContextDir, HostAMDCertFilename)
+	if err != nil {
+		return encodedUvmInformation, errors.Wrapf(err, "reading host amd cert failed")
+	}
+
+	if GenerateTestData {
+		ioutil.WriteFile("uvm_host_amd_certificate.base64", []byte(encodedHostCertsFromTHIM), 0644)
+	}
+
+	if encodedHostCertsFromTHIM != "" {
+		certChain, err := THIMtoPEM(encodedHostCertsFromTHIM)
+		if err != nil {
+			return encodedUvmInformation, err
+		}
+		encodedUvmInformation.CertChain = certChain
+	}
+
+	encodedUvmInformation.EncodedSecurityPolicy, err = readSecurityContextFile(securityContextDir, PolicyFilename)
+	if err != nil {
+		return encodedUvmInformation, errors.Wrapf(err, "reading host amd cert failed")
+	}
+
+	encodedUvmInformation.EncodedUvmReferenceInfo, err = readSecurityContextFile(securityContextDir, ReferenceInfoFilename)
+	if err != nil {
+		return encodedUvmInformation, errors.Wrapf(err, "reading host amd cert failed")
+	}
 
 	if GenerateTestData {
 		ioutil.WriteFile("uvm_security_policy.base64", []byte(encodedUvmInformation.EncodedSecurityPolicy), 0644)

--- a/tools/get-snp-report/Makefile
+++ b/tools/get-snp-report/Makefile
@@ -18,7 +18,7 @@ bin/get-snp-report: get-snp-report.o get-snp-report5.o get-snp-report6.o helpers
 	@mkdir -p bin
 	$(CC) $(LDFLAGS) -o $@ $^
 
-bin/verbose-report: verbose-report.o
+bin/verbose-report: verbose-report.o get-snp-report5.o get-snp-report6.o helpers.o
 	@mkdir -p bin
 	$(CC) $(LDFLAGS) -o $@ $^
 

--- a/tools/get-snp-report/verbose-report.c
+++ b/tools/get-snp-report/verbose-report.c
@@ -1,235 +1,47 @@
 /* Copyright (c) Microsoft Corporation.
    Licensed under the MIT License. */
-   
+
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <memory.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
-/* From sev-snp driver include/uapi/linux/psp-sev-guest.h */
+#include "snp-attestation.h"
+#include "fetch5.h"
+#include "fetch6.h"
 
-struct sev_snp_guest_request {
-	uint8_t req_msg_type;
-	uint8_t rsp_msg_type;
-	uint8_t msg_version;
-	uint16_t request_len;
-	uint64_t request_uaddr;
-	uint16_t response_len;
-	uint64_t response_uaddr;
-	uint32_t error;		/* firmware error code on failure (see psp-sev.h) */
-};
+#include "helpers.h"
 
-enum snp_msg_type {
-	SNP_MSG_TYPE_INVALID = 0,
-	SNP_MSG_CPUID_REQ,
-	SNP_MSG_CPUID_RSP,
-	SNP_MSG_KEY_REQ,
-	SNP_MSG_KEY_RSP,
-	SNP_MSG_REPORT_REQ,
-	SNP_MSG_REPORT_RSP,
-	SNP_MSG_EXPORT_REQ,
-	SNP_MSG_EXPORT_RSP,
-	SNP_MSG_IMPORT_REQ,
-	SNP_MSG_IMPORT_RSP,
-	SNP_MSG_ABSORB_REQ,
-	SNP_MSG_ABSORB_RSP,
-	SNP_MSG_VMRK_REQ,
-	SNP_MSG_VMRK_RSP,
-	SNP_MSG_TYPE_MAX
-};
+// Main expects the hex string representation of the report data as the only argument
+// Prints the raw binary format of the report so it can be consumed by the tools under
+// the directory internal/guest/attestation
 
-#define SEV_GUEST_IOC_TYPE		'S'
-#define SEV_SNP_GUEST_MSG_REQUEST	_IOWR(SEV_GUEST_IOC_TYPE, 0x0, struct sev_snp_guest_request)
-#define SEV_SNP_GUEST_MSG_REPORT	_IOWR(SEV_GUEST_IOC_TYPE, 0x1, struct sev_snp_guest_request)
-#define SEV_SNP_GUEST_MSG_KEY		_IOWR(SEV_GUEST_IOC_TYPE, 0x2, struct sev_snp_guest_request)
+int main(int argc, char *argv[])
+{    
+    bool success = false;
+    uint8_t *snp_report_hex;
+    const char *report_data_hexstring = "";
 
-#define PRINT_VAL(ptr, field) printBytes(#field, (const uint8_t *)&(ptr->field), sizeof(ptr->field), true)
-#define PRINT_BYTES(ptr, field) printBytes(#field, (const uint8_t *)&(ptr->field), sizeof(ptr->field), false)
-
-/* from SEV-SNP Firmware ABI Specification Table 20 */
-
-typedef struct {
-    uint8_t report_data[64];
-    uint32_t vmpl;
-    uint8_t reserved[28]; // needs to be zero
-} msg_report_req;
-
-/* from SEV-SNP Firmware ABI Specification from Table 21 */
-
-typedef struct {
-    uint32_t    version;            // version no. of this attestation report. Set to 1 for this specification. Now 2 with production silicon
-    uint32_t    guest_svn;          // The guest SVN
-    uint64_t    policy;             // see table 8 - various settings
-    __uint128_t family_id;          // as provided at launch
-    __uint128_t image_id;           // as provided at launch
-    uint32_t    vmpl;               // the request VMPL for the attestation report
-    uint32_t    signature_algo;
-    uint64_t    platform_version;   // The install version of the firmware
-    uint64_t    platform_info;      // information about the platform see table 22
-    // not going to try to use bit fields for this next one. Too confusing as to which bit of the byte will be used. Make a mask if you need it
-    uint32_t    author_key_en;      // 31 bits of reserved, must be zero, bottom bit indicates that the digest of the
-                                    // author key is present in AUTHOR_KEY_DIGEST. Set to the value of GCTX.AuthorKeyEn.
-    uint32_t    reserved1;          // must be zero
-    uint8_t     report_data[64];    // Guest provided data.
-    uint8_t     measurement[48];    // measurement calculated at launch
-    uint8_t     host_data[32];      // data provided by the hypervisor at launch
-    uint8_t     id_key_digest[48];  // SHA-384 digest of the ID public key that signed the ID block provided in SNP_LAUNCH_FINISH
-    uint8_t     author_key_digest[48];  // SHA-384 digest of the Author public key that certified the ID key, if provided in SNP_LAUNCH_FINISH. Zeros if author_key_en is 1 (sounds backwards to me).
-    uint8_t     report_id[32];      // Report ID of this guest.
-    uint8_t     report_id_ma[32];   // Report ID of this guest's mmigration agent.
-    uint64_t    reported_tcb;       // Reported TCB version used to derive the VCEK that signed this report
-    uint8_t     reserved2[24];      // reserved
-    uint8_t     chip_id[64];        // Identifier unique to the chip
-    uint8_t     committed_svn[8];   // The current commited SVN of the firware (version 2 report feature)
-    uint8_t     committed_version[8];   // The current commited version of the firware
-    uint8_t     launch_svn[8];      // The SVN that this guest was launched or migrated at
-    uint8_t     reserved3[168];     // reserved
-    uint8_t     signature[512];     // Signature of this attestation report. See table 23.
-} snp_attestation_report;
-
-/* from SEV-SNP Firmware ABI Specification Table 22 */
-
-typedef struct {
-    uint32_t status;
-    uint32_t report_size;
-    uint8_t reserved[24];    
-    snp_attestation_report report;
-    uint8_t padding[64]; // padding to the size of SEV_SNP_REPORT_RSP_BUF_SZ (i.e., 1280 bytes)
-} msg_response_resp;
-
-void printBytes(const char *desc, const uint8_t *data, size_t len, bool swap)
-{
-    printf("  %s: ", desc);
-    int padding = 20 - strlen(desc);
-    if (padding < 0)
-        padding = 0;
-    for (int count = 0; count < padding; count++)
-        putchar(' ');
-
-    for (size_t pos = 0; pos < len; pos++) {
-        printf("%02x", data[swap ? len - pos - 1 : pos]);
-        if (pos % 32 == 31)
-            printf("\n                        ");
-        else if (pos % 16 == 15)
-            putchar(' ');
-    }
-    printf("\n");
-}
-
-void printReport(const snp_attestation_report *r)
-{
-    printf("SNP attestation report:\n");
-    PRINT_VAL(r, version);              // print the version as an actual number
-    PRINT_VAL(r, guest_svn);
-    PRINT_VAL(r, policy);
-    PRINT_VAL(r, family_id);
-    PRINT_VAL(r, image_id);
-    PRINT_VAL(r, vmpl);
-    PRINT_VAL(r, signature_algo);
-    PRINT_BYTES(r, platform_version);   // dump the platform version as hex bytes
-    PRINT_BYTES(r, platform_info);
-    PRINT_VAL(r, author_key_en);
-    PRINT_VAL(r, reserved1);
-    PRINT_BYTES(r, report_data);
-    PRINT_BYTES(r, measurement);
-    PRINT_BYTES(r, host_data);
-    PRINT_BYTES(r, id_key_digest);
-    PRINT_BYTES(r, author_key_digest);
-    PRINT_BYTES(r, report_id);
-    PRINT_BYTES(r, report_id_ma);
-    PRINT_VAL(r, reported_tcb);
-    PRINT_BYTES(r, reserved2);
-    PRINT_BYTES(r, chip_id);
-    PRINT_BYTES(r, committed_svn);
-    PRINT_BYTES(r, committed_version);
-    PRINT_BYTES(r, launch_svn);
-    PRINT_BYTES(r, reserved3);
-    PRINT_BYTES(r, signature);
-}
-
-uint8_t* decodeHexString(char *hexstring)
-{   
-    size_t len = strlen(hexstring);
-    uint8_t *byte_array = (uint8_t*) malloc(strlen(hexstring)*sizeof(uint8_t));
-    
-    for (size_t i = 0; i < len; i+=2) {        
-        sscanf(hexstring, "%2hhx", &byte_array[i/2]);
-        hexstring += 2;        
+    if (argc > 1) {
+        report_data_hexstring = argv[1];
     }
 
-    return byte_array;
-}
-
-
-int main(int argc, char** argv)
-{
-    msg_report_req msg_report_in;    
-    msg_response_resp msg_report_out;
-
-	int fd;
-	int i;
-    int rc;
-    
-	struct sev_snp_guest_request payload = {
-		.req_msg_type = SNP_MSG_REPORT_REQ,
-		.rsp_msg_type = SNP_MSG_REPORT_RSP,
-		.msg_version = 1,        
-		.request_len = sizeof(msg_report_in),
-		.request_uaddr = (uint64_t) (void*) &msg_report_in,
-		.response_len = sizeof(msg_report_out),
-		.response_uaddr = (uint64_t) (void*) &msg_report_out,
-		.error = 0
-	};
-    
-    memset((void*) &msg_report_in, 0, sizeof(msg_report_in));        
-    memset((void*) &msg_report_out, 0, sizeof(msg_report_out));
-    // default to zeros
-    memset(msg_report_in.report_data, 0x00, sizeof(msg_report_in.report_data));
-            // todo: sha-512 key configuration structure to be used as report_data
-    if (argc >1) {
-        char *hexstring = argv[1];
-        size_t to_copy = (strlen(hexstring)+1)/2;
-        if (to_copy < sizeof(msg_report_in.report_data))
-            to_copy = sizeof(msg_report_in.report_data);
-    
-        for (size_t i = 0; i < to_copy; i++) {        
-            sscanf(hexstring, "%2hhx", &msg_report_in.report_data[i]);
-            hexstring += 2;        
-        }
+    if (supportsDevSev()) {
+        success = fetchAttestationReport5(report_data_hexstring, (void*) &snp_report_hex);
+    } else if (supportsDevSevGuest()) {
+        success = fetchAttestationReport6(report_data_hexstring, (void*) &snp_report_hex);
+    } else {
+        fprintf(stderr, "No supported SNP device found\n");
     }
-
-	fd = open("/dev/sev", O_RDWR | O_CLOEXEC);
-
-	if (fd < 0) {
-		printf("Failed to open /dev/sev\n");
-		exit(-1);
-	}
-
-	rc = ioctl(fd, SEV_SNP_GUEST_MSG_REPORT, &payload);
-
-    if (rc < 0) {
-        printf("Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT\n");        
-        exit(-1);    
+   
+    if (success) {
+        printReport((const snp_attestation_report *)snp_report_hex);
+        exit(0);
     }
-
-    printf("Response header:\n");
-
-    uint8_t *hdr = (uint8_t*) &msg_report_out;
-    
-	for (i = 0; i < 32; i++) {
-		printf("%02x", hdr[i]);
-		if (i % 16 == 15)
-			printf("\n");
-		else
-			printf(" ");
-	}
-            
-    printReport(&msg_report_out.report);
-    exit(0);
+    return 1;
 }

--- a/tools/securitypolicydigest/main.go
+++ b/tools/securitypolicydigest/main.go
@@ -13,8 +13,8 @@ import (
 
 /*
 	This tool computes the sha-256 digest of the security policy.
-	The input is already base64 
-
+	The input is already base64 encoded as that is required for the ARM template/API
+	so taking that format is more convienient.
  */
 
 func main() {

--- a/tools/securitypolicydigest/main.go
+++ b/tools/securitypolicydigest/main.go
@@ -11,30 +11,61 @@ import (
 	"os"
 )
 
+/*
+	This tool computes the sha-256 digest of the security policy.
+	The input is already base64 
+
+ */
+
 func main() {
 	// variables declaration
 	var encodedSecurityPolicy string
+	var verbose bool
+	var filename string
 
 	// flags declaration using flag package
 	flag.StringVar(&encodedSecurityPolicy, "p", "", "Security policy in base64-encoded string format")
-	flag.Parse() // after declaring flags we need to call it
-
+	flag.StringVar(&filename, "f", "", "file containing ecurity policy in base64-encoded string format")
+	flag.BoolVar(&verbose, "v", false, "print the decoded security policy")
 	flag.Parse()
-	if flag.NArg() != 0 || len(encodedSecurityPolicy) == 0 {
+
+	if flag.NArg() != 0 {
 		flag.Usage()
 		os.Exit(1)
 	}
 
+	if len(filename) != 0 {
+		if len(encodedSecurityPolicy) != 0 {
+			fmt.Println("Cannot specify both -p and -f")
+			flag.Usage()
+			os.Exit(1)
+		}
+		encodedSecurityPolicyBytes, err := os.ReadFile(filename)
+		if err != nil {
+			fmt.Printf("Could not decode file %s\n", filename)
+			os.Exit(1)
+		}
+		encodedSecurityPolicy = string(encodedSecurityPolicyBytes)
+	}
+
 	inittimeDataBytes, err := base64.StdEncoding.DecodeString(encodedSecurityPolicy)
 	if err != nil {
-		fmt.Println("Could not decode ")
+		fmt.Println("Could not decode - required base64 (Std, with padding) encoding")
 		os.Exit(1)
 	}
 
-	fmt.Printf("inittimeData %s", string(inittimeDataBytes))
+	if verbose {
+		fmt.Printf("inittimeData %s", string(inittimeDataBytes))
+	}
 
 	h := sha256.New()
 	h.Write(inittimeDataBytes)
 
-	fmt.Printf("inittimeData sha-256 digest %x", h.Sum(nil))
+	sum := h.Sum(nil)
+
+	if verbose {
+		fmt.Printf("inittimeData sha-256 digest %x\n", sum)
+	} else {
+		fmt.Printf("%x\n", sum)
+	}
 }

--- a/tools/securitypolicydigest/main.go
+++ b/tools/securitypolicydigest/main.go
@@ -15,7 +15,7 @@ import (
 	This tool computes the sha-256 digest of the security policy.
 	The input is already base64 encoded as that is required for the ARM template/API
 	so taking that format is more convienient.
- */
+*/
 
 func main() {
 	// variables declaration
@@ -25,7 +25,7 @@ func main() {
 
 	// flags declaration using flag package
 	flag.StringVar(&encodedSecurityPolicy, "p", "", "Security policy in base64-encoded string format")
-	flag.StringVar(&filename, "f", "", "file containing ecurity policy in base64-encoded string format")
+	flag.StringVar(&filename, "f", "", "file containing security policy in base64-encoded string format")
 	flag.BoolVar(&verbose, "v", false, "print the decoded security policy")
 	flag.Parse()
 
@@ -50,12 +50,12 @@ func main() {
 
 	inittimeDataBytes, err := base64.StdEncoding.DecodeString(encodedSecurityPolicy)
 	if err != nil {
-		fmt.Println("Could not decode - required base64 (Std, with padding) encoding")
+		fmt.Println("Could not decode: base64 encoding (Std, with padding) required")
 		os.Exit(1)
 	}
 
 	if verbose {
-		fmt.Printf("inittimeData %s", string(inittimeDataBytes))
+		fmt.Printf("inittimeData %s\n", string(inittimeDataBytes))
 	}
 
 	h := sha256.New()


### PR DESCRIPTION
Support file rather than env based scheme to acquire policy, uvm info and certs.

To match https://github.com/microsoft/hcsshim/pull/1708

This PR supports both methods to decouple testing/deployment. There will be a subsequent PR to remove support for the environment variable scheme.

This PR also includes a debug version of the skr container that allows ssh-ing into the containers for debugging purposes.