### PR TITLE
Check for sev-guest dev (6.1)

### DIFF
--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -18,11 +18,15 @@ import (
 // RawAttest returns the raw attestation report in hex string format
 func RawAttest(inittimeDataBytes []byte, runtimeDataBytes []byte) (string, error) {
 	// check if sev device exists on the platform; if not fetch fake snp report
-	var fetchRealSNPReport bool
-	if _, err := os.Stat("/dev/sev"); os.IsNotExist(err) {
-		fetchRealSNPReport = false
-	} else {
-		fetchRealSNPReport = true
+	// check if sev device exists on the platform; if not fetch fake snp report
+
+	fetchRealSNPReport := true
+	if _, err := os.Stat("/dev/sev"); errors.Is(err, os.ErrNotExist) {
+		// dev/sev doesn't exist, check dev/sev-guest
+		if _, err := os.Stat("/dev/sev-guest"); errors.Is(err, os.ErrNotExist) {
+			// dev/sev-guest doesn't exist
+			fetchRealSNPReport = false
+		}
 	}
 
 	SNPReportBytes, err := FetchSNPReport(fetchRealSNPReport, runtimeDataBytes, inittimeDataBytes)

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -51,11 +51,14 @@ func Attest(maa MAA, runtimeDataBytes []byte, uvmInformation common.UvmInformati
 	// Fetch the attestation report
 
 	// check if sev device exists on the platform; if not fetch fake snp report
-	var fetchRealSNPReport bool
-	if _, err := os.Stat("/dev/sev"); os.IsNotExist(err) {
-		fetchRealSNPReport = false
-	} else {
-		fetchRealSNPReport = true
+
+	fetchRealSNPReport := true
+	if _, err := os.Stat("/dev/sev"); errors.Is(err, os.ErrNotExist) {
+		// dev/sev doesn't exist, check dev/sev-guest
+		if _, err := os.Stat("/dev/sev-guest"); errors.Is(err, os.ErrNotExist) {
+			// dev/sev-guest doesn't exist
+			fetchRealSNPReport = false
+		}
 	}
 
 	inittimeDataBytes, err := base64.StdEncoding.DecodeString(uvmInformation.EncodedSecurityPolicy)


### PR DESCRIPTION
The PSP device is exposed as /dev/sev-guest rather than /dev/sev. When determining whether this is a real SNP box we need to check both. If not a real SNP box then a fake report is generated to allow for testing and development.