### PR TITLE
add retry when vcekcertchain is empty

### DIFF
--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -130,6 +130,7 @@ func (certState *CertState) Attest(maa MAA, runtimeDataBytes []byte, uvmInformat
 			}
 		}
 	} else {
+		//In case the initialCerts are not properly configured, we should fall back on fetching the vcekCert remotely
 		if uvmInformation.InitialCerts.VcekCert == "" || uvmInformation.InitialCerts.CertificateChain == "" {
 			SNPReportBytes, inittimeDataBytes, vcekCertChain, err = certState.refreshSNPReportAndCertChain(uvmInformation.EncodedSecurityPolicy, runtimeDataBytes)
 			if err != nil {
@@ -158,7 +159,6 @@ func (certState *CertState) Attest(maa MAA, runtimeDataBytes []byte, uvmInformat
 
 func (certState *CertState) refreshSNPReportAndCertChain(securityPolicy string, runtimeDataBytes []byte) ([]byte, []byte, []byte, error) {
 	var SNPReport SNPAttestationReport
-	// TCB values still don't match, try retrieving the SNP report again
 	SNPReportBytes, inittimeDataBytes, err := GetSNPReport(securityPolicy, runtimeDataBytes)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed to retrieve new attestation report")


### PR DESCRIPTION
The title explains the PR. Original thought was to use exponential backoffs on retrying. No need to retry for more than one time because if retry for once does not work, something must be badly configured - then the failure ought to surface. We also do not want to risk Azure being blacklisted by AMD.  