### PR TITLE
Fix paths pointing to clients in SKR sidecar

### DIFF
--- a/examples/skr/README.md
+++ b/examples/skr/README.md
@@ -6,9 +6,9 @@
 
 In our confidential container group example, we will deploy the skr sidecar along with a set of test containers that exercise and test the REST API.
 - **skr sidecar.** The sidecar’s entry point is /skr.sh which uses the SkrSideCarArgs environment variable to pass the certificate cache endpoint information.
-- **attest/raw test.** The sidecar’s entry point is /tests/attest_client.sh which uses the AttestClientRuntimeData environment variable to pass a blob whose sha-256 digest will be encoded in the raw attestation report as report_data.
-- **attest/maa test.** The sidecar’s entry point is /tests/attest_client.sh which uses two environment variables: (i) AttestClientMAAEndpoint passes the Microsoft Azure Attestation endpoint which will author the attestation token, (ii) AttestClientRuntimeData passes a blob whose sha-256 digest will be encoded in the attestation token as runtime claim.
-- **key/release test.** The sidecar’s entry point is /tests/skr_client.sh which uses the three environment variables: (i) SkrClientKID passes the key identifier of the key to be released from the key vault, (ii) SkrClientAKVEndpoint passes the key vault endpoint from which the key will be released, and (iii) SkrClientMAAEndpoint passes the Microsoft Azure Attestation endpoint shall author the attestation token required for releasing the secret. The MAA endpoint shall be the same as the one specified in the SKR policy during the key import to the key vault.
+- **attest/raw test.** The sidecar’s entry point is /tests/skr/attest_client.sh which uses the AttestClientRuntimeData environment variable to pass a blob whose sha-256 digest will be encoded in the raw attestation report as report_data.
+- **attest/maa test.** The sidecar’s entry point is /tests/skr/attest_client.sh which uses two environment variables: (i) AttestClientMAAEndpoint passes the Microsoft Azure Attestation endpoint which will author the attestation token, (ii) AttestClientRuntimeData passes a blob whose sha-256 digest will be encoded in the attestation token as runtime claim.
+- **key/release test.** The sidecar’s entry point is /tests/skr/skr_client.sh which uses the three environment variables: (i) SkrClientKID passes the key identifier of the key to be released from the key vault, (ii) SkrClientAKVEndpoint passes the key vault endpoint from which the key will be released, and (iii) SkrClientMAAEndpoint passes the Microsoft Azure Attestation endpoint shall author the attestation token required for releasing the secret. The MAA endpoint shall be the same as the one specified in the SKR policy during the key import to the key vault.
 
 
 ### Policy generation
@@ -20,7 +20,7 @@ The ARM template can be used directly to generate a security policy. The followi
 az confcom acipolicygen -a aci-skr-arm-template.json --debug-mode
 ```
 
-The ARM template file includes three entries: (i) skr sidecar container which whitelists the /skr.sh as entry point command and the environment variable SkrSideCarArgs used by the script, (ii) attest_client container which whitelists the /tests/attest_client.sh as entry point command and a set of environment variables used by the script and whose names begin with AttestClient, and  (iii) skr_client container which whitelists the /tests/skr_client.sh as entry point command and a set of environment variables used by the script and whose names begin with SkrClient. 
+The ARM template file includes three entries: (i) skr sidecar container which whitelists the /skr.sh as entry point command and the environment variable SkrSideCarArgs used by the script, (ii) attest_client container which whitelists the /tests/skr/attest_client.sh as entry point command and a set of environment variables used by the script and whose names begin with AttestClient, and  (iii) skr_client container which whitelists the /tests/skr/skr_client.sh as entry point command and a set of environment variables used by the script and whose names begin with SkrClient. 
 Please note that:
 - The skr sidecar must be allowed to execute as elevated because it needs access to the PSP which is mounted as a device at /dev/sev. 
 - The policy includes one entry for both attestation tests, as both tests use the same entry point and a superset of environment variables whitelisted by the AttestClient regular expression.

--- a/examples/skr/aci-arm-template.json
+++ b/examples/skr/aci-arm-template.json
@@ -48,7 +48,7 @@
             "name": "test-skr-client-container",
             "properties": {
               "command": [
-                "/tests/skr_client.sh"
+                "/tests/skr/skr_client.sh"
               ],
               "environmentVariables": [
                 {
@@ -77,7 +77,7 @@
             "name": "test-attest-client-container",
             "properties": {
               "command": [
-                "/tests/attest_client.sh"
+                "/tests/skr/attest_client.sh"
               ],
               "environmentVariables": [
                 {
@@ -98,7 +98,7 @@
             "name": "test-attest-maa-client-container",
             "properties": {
               "command": [
-                "/tests/attest_client.sh"
+                "/tests/skr/attest_client.sh"
               ],
               "environmentVariables": [
                 {


### PR DESCRIPTION
Previously paths for clients in the example arm template and README were /tests/*_client.sh but the dockerfile moves those scripts to /tests/skr/*_client.sh.

Fix the paths