### PR TITLE
Simplify tag derivation for image pushing

### DIFF
--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -9,6 +9,8 @@ jobs:
   cleanup_registry:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
         
       - name: Log in to Azure Container Registry
         run: |
@@ -22,7 +24,6 @@ jobs:
           REGISTRY_NAME: ${{ secrets.REGISTRY_NAME }}
         run: |
           repos=("skr" "skr_debug" "encfs")
-          git remote add origin https://github.com/microsoft/confidential-sidecar-containers
           branches=$(git ls-remote --heads origin)
           
           # Delete any tags which don't have a corresponding branch

--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -22,7 +22,8 @@ jobs:
           REGISTRY_NAME: ${{ secrets.REGISTRY_NAME }}
         run: |
           repos=("skr" "skr_debug" "encfs")
-          branches=$(git ls-remote)
+          git remote add origin https://github.com/microsoft/confidential-sidecar-containers
+          branches=$(git ls-remote --heads origin)
           
           # Delete any tags which don't have a corresponding branch
           for repo in "${repos[@]}"; do

--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Log in to Azure Container Registry
         run: |
           az acr login \
-            --name $REGISTRY_NAME \
-            --username $REGISTRY_NAME \
-            --password $REGISTRY_PASSWORD
+            --name ${{ secrets.REGISTRY_NAME }} \
+            --username ${{ secrets.REGISTRY_NAME }} \
+            --password ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Cleanup Registry
         env:

--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -14,31 +14,29 @@ jobs:
         
       - name: Log in to Azure Container Registry
         run: |
-          az login \
-            --username ${{ secrets.REGISTRY_NAME }} \
-            --password ${{ secrets.REGISTRY_PASSWORD }}
           az acr login \
-            --name ${{ secrets.REGISTRY_NAME }} \
-            --username ${{ secrets.REGISTRY_NAME }} \
-            --password ${{ secrets.REGISTRY_PASSWORD }}
+            --name $REGISTRY_NAME \
+            --username $REGISTRY_NAME \
+            --password $REGISTRY_PASSWORD
 
       - name: Cleanup Registry
         env:
           REGISTRY_NAME: ${{ secrets.REGISTRY_NAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
           repos=("skr" "skr_debug" "encfs")
           branches=$(git ls-remote --heads origin)
           
           # Delete any tags which don't have a corresponding branch
           for repo in "${repos[@]}"; do
-            tags=$(az acr repository show-tags --name $REGISTRY_NAME --repository $repo | jq -r '.[]')
+            tags=$(az acr repository show-tags --name $REGISTRY_NAME -u $REGISTRY_NAME -p $REGISTRY_PASSWORD --repository $repo | jq -r '.[]')
             for tag in $tags; do
               echo "Checking $repo:$tag"
               if [[ $branches =~ $tag ]]; then
                 echo "Branch $tag still exists"
               else
                 echo "Branch $tag no longer exists, deleting tag"
-                az acr repository delete --name $REGISTRY_NAME --image $repo:$tag --yes
+                az acr repository delete --name $REGISTRY_NAME -u $REGISTRY_NAME -p $REGISTRY_PASSWORD --image $repo:$tag --yes
               fi
             done
           done

--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -22,7 +22,7 @@ jobs:
           REGISTRY_NAME: ${{ secrets.REGISTRY_NAME }}
         run: |
           repos=("skr" "skr_debug" "encfs")
-          branches=$(git ls-remote --heads origin)
+          branches=$(git ls-remote)
           
           # Delete any tags which don't have a corresponding branch
           for repo in "${repos[@]}"; do

--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -14,6 +14,9 @@ jobs:
         
       - name: Log in to Azure Container Registry
         run: |
+          az login \
+            --username ${{ secrets.REGISTRY_NAME }} \
+            --password ${{ secrets.REGISTRY_PASSWORD }}
           az acr login \
             --name ${{ secrets.REGISTRY_NAME }} \
             --username ${{ secrets.REGISTRY_NAME }} \

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -38,16 +38,7 @@ jobs:
             --name ${{ secrets.REGISTRY_NAME }} \
             --username ${{ secrets.REGISTRY_NAME }} \
             --password ${{ secrets.REGISTRY_PASSWORD }}
-          
-      - name: Get Branch Name
-        id: get_branch_name
-        run: |
-          if [ ${{ github.event_name }} == "pull_request" ]; then
-            echo "branch_name=$(echo ${{ github.head_ref }})" >> $GITHUB_OUTPUT
-          else
-            echo "branch_name=$(echo ${{ github.ref }})" >> $GITHUB_OUTPUT
-          fi
-        
+
       - name: Build Image
         run: docker/encfs/build.sh
         
@@ -56,5 +47,5 @@ jobs:
           docker/encfs/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            encfs:${{ steps.get_branch_name.outputs.branch_name }} \
+            encfs:${{ github.head_ref }} \
             --skip-login

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -38,16 +38,7 @@ jobs:
             --name ${{ secrets.REGISTRY_NAME }} \
             --username ${{ secrets.REGISTRY_NAME }} \
             --password ${{ secrets.REGISTRY_PASSWORD }}
-          
-      - name: Get Branch Name
-        id: get_branch_name
-        run: |
-          if [ ${{ github.event_name }} == "pull_request" ]; then
-            echo "branch_name=$(echo ${{ github.head_ref }})" >> $GITHUB_OUTPUT
-          else
-            echo "branch_name=$(echo ${{ github.ref }})" >> $GITHUB_OUTPUT
-          fi
-        
+
       - name: Build Image
         run: docker/skr/build-debug.sh
         
@@ -56,5 +47,5 @@ jobs:
           docker/skr/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            skr_debug:${{ steps.get_branch_name.outputs.branch_name }} \
+            skr_debug:${{ github.head_ref }} \
             --skip-login

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -36,16 +36,7 @@ jobs:
             --name ${{ secrets.REGISTRY_NAME }} \
             --username ${{ secrets.REGISTRY_NAME }} \
             --password ${{ secrets.REGISTRY_PASSWORD }}
-          
-      - name: Get Branch Name
-        id: get_branch_name
-        run: |
-          if [ ${{ github.event_name }} == "pull_request" ]; then
-            echo "branch_name=$(echo ${{ github.head_ref }})" >> $GITHUB_OUTPUT
-          else
-            echo "branch_name=$(echo ${{ github.ref }})" >> $GITHUB_OUTPUT
-          fi
-        
+
       - name: Build Image
         run: docker/skr/build.sh
         
@@ -54,5 +45,5 @@ jobs:
           docker/skr/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            skr:${{ steps.get_branch_name.outputs.branch_name }} \
+            skr:${{ github.head_ref }} \
             --skip-login


### PR DESCRIPTION
The original PR anticipated a difference in where the branch name would be in the GitHub context depending on the event trigger, this turned out not to be needed so it's been removed.

Also fixed credential passing and branch fetching for the cleanup workflow as this couldn't be tested by triggering the workflow until the workflow existed on main 