### PR TITLE
Allow credentials access from fork PRs

### DIFF
--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -5,6 +5,13 @@ on:
   pull_request_target:
     branches:
       - main
+    paths:
+      - .github/workflows/push_encfs_image.yml
+      - cmd/azmount/**
+      - cmd/remotefs/**
+      - docker/encfs/**
+      - tools/get-snp-report/bin/get-snp-report
+      - tools/get-snp-report/bin/get-fake-snp-report
   push:
     branches:
       - main

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -5,13 +5,6 @@ on:
   pull_request_target:
     branches:
       - main
-    paths:
-      - .github/workflows/push_encfs_image.yml
-      - cmd/azmount/**
-      - cmd/remotefs/**
-      - docker/encfs/**
-      - tools/get-snp-report/bin/get-snp-report
-      - tools/get-snp-report/bin/get-fake-snp-report
   push:
     branches:
       - main

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -1,7 +1,7 @@
 name: Push Encrypted FS Image
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -21,16 +21,17 @@ on:
       - docker/encfs/**
       - tools/get-snp-report/bin/get-snp-report
       - tools/get-snp-report/bin/get-fake-snp-report
-    
-      
-jobs:
 
-  push-encfs-image: 
+jobs:
+  push-encfs-image:
     name: Push Encrypted FS Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Log in to Azure Container Registry
         run: |
@@ -38,7 +39,7 @@ jobs:
             --name ${{ secrets.REGISTRY_NAME }} \
             --username ${{ secrets.REGISTRY_NAME }} \
             --password ${{ secrets.REGISTRY_PASSWORD }}
-          
+
       - name: Get Branch Name
         id: get_branch_name
         run: |
@@ -47,10 +48,10 @@ jobs:
           else
             echo "branch_name=$(echo ${{ github.ref }})" >> $GITHUB_OUTPUT
           fi
-        
+
       - name: Build Image
         run: docker/encfs/build.sh
-        
+
       - name: Push Image
         run: |
           docker/encfs/push.sh \

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -46,8 +46,13 @@ jobs:
 
       - name: Push Image
         run: |
+          if [ ${{ github.event_name }} == "push" ]; then
+            branch_name=main
+          else  
+            branch_name=$(echo ${{ github.head_ref }})
+          fi
           docker/encfs/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            encfs:${{ github.head_ref }} \
+            skr:$branch_name \
             --skip-login

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -2,16 +2,9 @@ name: Push Encrypted FS Image
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches:
       - main
-    paths:
-      - .github/workflows/push_encfs_image.yml
-      - cmd/azmount/**
-      - cmd/remotefs/**
-      - docker/encfs/**
-      - tools/get-snp-report/bin/get-snp-report
-      - tools/get-snp-report/bin/get-fake-snp-report
   push:
     branches:
       - main

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -54,5 +54,5 @@ jobs:
           docker/encfs/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            skr:$branch_name \
+            encfs:$branch_name \
             --skip-login

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -1,6 +1,7 @@
 name: Push Encrypted FS Image
 
 on:
+  workflow_dispatch:
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -2,9 +2,16 @@ name: Push Encrypted FS Image
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - main
+    paths:
+      - .github/workflows/push_encfs_image.yml
+      - cmd/azmount/**
+      - cmd/remotefs/**
+      - docker/encfs/**
+      - tools/get-snp-report/bin/get-snp-report
+      - tools/get-snp-report/bin/get-fake-snp-report
   push:
     branches:
       - main

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -47,8 +47,13 @@ jobs:
         
       - name: Push Image
         run: |
+          if [ ${{ github.event_name }} == "push" ]; then
+            branch_name=main
+          else  
+            branch_name=$(echo ${{ github.head_ref }})
+          fi
           docker/skr/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            skr_debug:${{ github.head_ref }} \
+            skr_debug:$branch_name \
             --skip-login

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -1,6 +1,7 @@
 name: Push SKR Debug Image
 
 on:
+  workflow_dispatch:
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -1,7 +1,7 @@
 name: Push SKR Debug Image
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -31,6 +31,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Log in to Azure Container Registry
         run: |

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -24,7 +24,6 @@ on:
       - tools/get-snp-report/bin/verbose-report
       
 jobs:
-
   push-skr-debug-image: 
     name: Push SKR Debug Image
     runs-on: ubuntu-latest

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -45,8 +45,13 @@ jobs:
 
       - name: Push Image
         run: |
+          if [ ${{ github.event_name }} == "push" ]; then
+            branch_name=main
+          else  
+            branch_name=$(echo ${{ github.head_ref }})
+          fi
           docker/skr/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            skr:${{ github.head_ref }} \
+            skr:$branch_name \
             --skip-login

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -1,7 +1,7 @@
 name: Push SKR Image
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -10,7 +10,7 @@ on:
       - docker/skr/**
       - tools/get-snp-report/bin/get-snp-report
       - tools/get-snp-report/bin/get-fake-snp-report
-      
+
   push:
     branches:
       - main
@@ -20,23 +20,25 @@ on:
       - docker/skr/**
       - tools/get-snp-report/bin/get-snp-report
       - tools/get-snp-report/bin/get-fake-snp-report
-      
-jobs:
 
-  push-skr-image: 
+jobs:
+  push-skr-image:
     name: Push SKR Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
       - name: Log in to Azure Container Registry
         run: |
           az acr login \
             --name ${{ secrets.REGISTRY_NAME }} \
             --username ${{ secrets.REGISTRY_NAME }} \
             --password ${{ secrets.REGISTRY_PASSWORD }}
-          
+
       - name: Get Branch Name
         id: get_branch_name
         run: |
@@ -45,10 +47,10 @@ jobs:
           else
             echo "branch_name=$(echo ${{ github.ref }})" >> $GITHUB_OUTPUT
           fi
-        
+
       - name: Build Image
         run: docker/skr/build.sh
-        
+
       - name: Push Image
         run: |
           docker/skr/push.sh \

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -1,6 +1,7 @@
 name: Push SKR Image
 
 on:
+  workflow_dispatch:
   pull_request_target:
     branches:
       - main


### PR DESCRIPTION
Use the pull request target event instead of pull request which allows repository secrets access under the basis that it runs against the target branch so malicious PRs cannot leak the secret without already merging something to main. We then checkout the PR head which makes it equivalent to using pull_request only with access to the secrets.

The safety of this approach is based on the fact that this repository (at least at the time of writing) requires approval from someone with write access for a PR from an outside fork to run the actions. This means the this is only safe under the following conditions:
- We don't change the setting allowing anyone to run actions on their fork PRs
- All admins of this repo are careful which PRs they approve to run actions