### PR TITLE
Revert to pull_request event

### DIFF
--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -2,7 +2,7 @@ name: Push Encrypted FS Image
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -2,7 +2,7 @@ name: Push SKR Debug Image
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -2,7 +2,7 @@ name: Push SKR Image
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:


### PR DESCRIPTION
The pull_request_target event isn't subject to the repository setting which requires permission for outside forks to run a workflow